### PR TITLE
Problem: string reverse program does not reverse string of length 2

### DIFF
--- a/src/string/string.c
+++ b/src/string/string.c
@@ -109,7 +109,7 @@ void swap(char *src, unsigned start, unsigned end)
 
 char *revStrRecursion(char *str, unsigned start, unsigned end)
 {
-  if(end <= 1)
+  if(end < 1)
     return str;
 
   if (start >= end)


### PR DESCRIPTION
Solution remove `end <= 1` to `end < 1`
closes issue #13 